### PR TITLE
Implement texture slot hashing

### DIFF
--- a/source/rengine/graphics/imgui_manager_private.cpp
+++ b/source/rengine/graphics/imgui_manager_private.cpp
@@ -339,8 +339,8 @@ namespace rengine {
 						continue;
 
 					// TODO: implement scissors
-					const auto tex = cmd->GetTexID();
-					renderer_set_texture_2d(0, tex);
+                                        const auto tex = cmd->GetTexID();
+                                        renderer_set_texture_2d("g_texture", tex);
 
 					draw_indexed_desc draw_desc = {};
 					draw_desc.num_indices = cmd->ElemCount;

--- a/source/rengine/graphics/render_command.cpp
+++ b/source/rengine/graphics/render_command.cpp
@@ -3,6 +3,7 @@
 
 #include "../exceptions.h"
 #include "../core/allocator.h"
+#include "../core/string_pool.h"
 
 #include <fmt/format.h>
 
@@ -98,33 +99,65 @@ namespace rengine {
 			render_command__set_rts(cmd, render_targets, num_rts, depth_id);
 		}
 		
-		void render_command_set_tex2d(const u8& tex_slot, const texture_2d_t& tex_id)
-		{
-			ASSERT_RENDER_COMMAND_UPDATE();
-			auto& cmd = *g_render_command_state.curr_cmd;
-			render_command__set_tex2d(cmd, tex_slot, tex_id);
-		}
-		
-		void render_command_set_tex3d(const u8& tex_slot, const texture_3d_t& tex_id)
-		{
-			ASSERT_RENDER_COMMAND_UPDATE();
-			auto& cmd = *g_render_command_state.curr_cmd;
-			render_command__set_tex2d(cmd, tex_slot, tex_id);
-		}
-		
-		void render_command_set_texcube(const u8& tex_slot, const texture_cube_t& tex_id)
-		{
-			ASSERT_RENDER_COMMAND_UPDATE();
-			auto& cmd = *g_render_command_state.curr_cmd;
-			render_command__set_texcube(cmd, tex_slot, tex_id);
-		}
-		
-		void render_command_set_texarray(const u8& tex_slot, const texture_array_t& tex_id)
-		{
-			ASSERT_RENDER_COMMAND_UPDATE();
-			auto& cmd = *g_render_command_state.curr_cmd;
-			render_command__set_texarray(cmd, tex_slot, tex_id);
-		}
+                void render_command_set_tex2d(c_str slot_name, const texture_2d_t& tex_id)
+                {
+                        ASSERT_RENDER_COMMAND_UPDATE();
+                        core::hash_t slot_hash{};
+                        core::string_pool_intern(slot_name, &slot_hash);
+                        render_command_set_tex2d(slot_hash, tex_id);
+                }
+
+                void render_command_set_tex3d(c_str slot_name, const texture_3d_t& tex_id)
+                {
+                        ASSERT_RENDER_COMMAND_UPDATE();
+                        core::hash_t slot_hash{};
+                        core::string_pool_intern(slot_name, &slot_hash);
+                        render_command_set_tex3d(slot_hash, tex_id);
+                }
+
+                void render_command_set_texcube(c_str slot_name, const texture_cube_t& tex_id)
+                {
+                        ASSERT_RENDER_COMMAND_UPDATE();
+                        core::hash_t slot_hash{};
+                        core::string_pool_intern(slot_name, &slot_hash);
+                        render_command_set_texcube(slot_hash, tex_id);
+                }
+
+                void render_command_set_texarray(c_str slot_name, const texture_array_t& tex_id)
+                {
+                        ASSERT_RENDER_COMMAND_UPDATE();
+                        core::hash_t slot_hash{};
+                        core::string_pool_intern(slot_name, &slot_hash);
+                        render_command_set_texarray(slot_hash, tex_id);
+                }
+
+                void render_command_set_tex2d(core::hash_t slot, const texture_2d_t& tex_id)
+                {
+                        ASSERT_RENDER_COMMAND_UPDATE();
+                        auto& cmd = *g_render_command_state.curr_cmd;
+                        render_command__set_tex2d(cmd, slot, tex_id);
+                }
+
+                void render_command_set_tex3d(core::hash_t slot, const texture_3d_t& tex_id)
+                {
+                        ASSERT_RENDER_COMMAND_UPDATE();
+                        auto& cmd = *g_render_command_state.curr_cmd;
+                        render_command__set_tex3d(cmd, slot, tex_id);
+                }
+
+                void render_command_set_texcube(core::hash_t slot, const texture_cube_t& tex_id)
+                {
+                        ASSERT_RENDER_COMMAND_UPDATE();
+                        auto& cmd = *g_render_command_state.curr_cmd;
+                        render_command__set_texcube(cmd, slot, tex_id);
+                }
+
+                void render_command_set_texarray(core::hash_t slot, const texture_array_t& tex_id)
+                {
+                        ASSERT_RENDER_COMMAND_UPDATE();
+                        auto& cmd = *g_render_command_state.curr_cmd;
+                        render_command__set_texarray(cmd, slot, tex_id);
+                }
 		
 		void render_command_set_viewport(const math::urect& rect)
 		{

--- a/source/rengine/graphics/render_command_private.cpp
+++ b/source/rengine/graphics/render_command_private.cpp
@@ -6,6 +6,7 @@
 #include "../strings.h"
 #include "../exceptions.h"
 #include "../core/hash.h"
+#include "../core/string_pool.h"
 
 #include <fmt/format.h>
 namespace rengine {
@@ -172,25 +173,53 @@ namespace rengine {
 			cmd.depth_stencil = depth_id;
 		}
 
-		void render_command__set_tex2d(render_command_data& cmd, const u8& slot, const texture_2d_t& id)
-		{
-			throw not_implemented_exception();
-		}
+                void render_command__set_tex2d(render_command_data& cmd, const core::hash_t& slot, const texture_2d_t& id)
+                {
+                        render_command_texture_resource res{};
+                        res.type = texture_type::tex2d;
+                        res.tex_id = id;
+                        res.resource.id = slot;
+                        res.resource.type = shader_resource_type::texture;
+                        res.resource.name = core::string_pool_get_from_hash(slot);
+                        cmd.textures[slot] = res;
+                        cmd.srb = no_srb;
+                }
 
-		void render_command__set_tex3d(render_command_data& cmd, const u8& slot, const texture_3d_t& id)
-		{
-			throw not_implemented_exception();
-		}
+                void render_command__set_tex3d(render_command_data& cmd, const core::hash_t& slot, const texture_3d_t& id)
+                {
+                        render_command_texture_resource res{};
+                        res.type = texture_type::tex3d;
+                        res.tex_id = id;
+                        res.resource.id = slot;
+                        res.resource.type = shader_resource_type::texture;
+                        res.resource.name = core::string_pool_get_from_hash(slot);
+                        cmd.textures[slot] = res;
+                        cmd.srb = no_srb;
+                }
 
-		void render_command__set_texcube(render_command_data& cmd, const u8& slot, const texture_cube_t& id)
-		{
-			throw not_implemented_exception();
-		}
+                void render_command__set_texcube(render_command_data& cmd, const core::hash_t& slot, const texture_cube_t& id)
+                {
+                        render_command_texture_resource res{};
+                        res.type = texture_type::texcube;
+                        res.tex_id = id;
+                        res.resource.id = slot;
+                        res.resource.type = shader_resource_type::texture;
+                        res.resource.name = core::string_pool_get_from_hash(slot);
+                        cmd.textures[slot] = res;
+                        cmd.srb = no_srb;
+                }
 
-		void render_command__set_texarray(render_command_data& cmd, const u8& slot, const texture_array_t& id)
-		{
-			throw not_implemented_exception();
-		}
+                void render_command__set_texarray(render_command_data& cmd, const core::hash_t& slot, const texture_array_t& id)
+                {
+                        render_command_texture_resource res{};
+                        res.type = texture_type::texarray;
+                        res.tex_id = id;
+                        res.resource.id = slot;
+                        res.resource.type = shader_resource_type::texarray;
+                        res.resource.name = core::string_pool_get_from_hash(slot);
+                        cmd.textures[slot] = res;
+                        cmd.srb = no_srb;
+                }
 
 		void render_command__set_viewport(render_command_data& cmd, const math::urect& rect)
 		{

--- a/source/rengine/graphics/renderer.cpp
+++ b/source/rengine/graphics/renderer.cpp
@@ -7,6 +7,7 @@
 #include "../core/allocator.h"
 #include "../core/window_private.h"
 #include "../core/profiler.h"
+#include "../core/string_pool.h"
 #include "../io/io.h"
 #include "../exceptions.h"
 
@@ -126,29 +127,61 @@ namespace rengine {
 			render_command__set_rts(cmd, render_targets, num_rts, depth_id);
 		}
 
-		void renderer_set_texture_2d(const u8& tex_slot, const texture_2d_t& tex_id)
-		{
-			auto& cmd = g_renderer_state.default_cmd;
-			render_command__set_tex2d(cmd, tex_slot, tex_id);
-		}
+                void renderer_set_texture_2d(c_str slot_name, const texture_2d_t& tex_id)
+                {
+                        auto& cmd = g_renderer_state.default_cmd;
+                        core::hash_t slot_hash{};
+                        core::string_pool_intern(slot_name, &slot_hash);
+                        render_command__set_tex2d(cmd, slot_hash, tex_id);
+                }
 
-		void renderer_set_texture_3d(const u8& tex_slot, const texture_3d_t& tex_id)
-		{
-			auto& cmd = g_renderer_state.default_cmd;
-			render_command__set_tex3d(cmd, tex_slot, tex_id);
-		}
+                void renderer_set_texture_3d(c_str slot_name, const texture_3d_t& tex_id)
+                {
+                        auto& cmd = g_renderer_state.default_cmd;
+                        core::hash_t slot_hash{};
+                        core::string_pool_intern(slot_name, &slot_hash);
+                        render_command__set_tex3d(cmd, slot_hash, tex_id);
+                }
 
-		void renderer_set_texture_cube(const u8& tex_slot, const texture_cube_t& tex_id)
-		{
-			auto& cmd = g_renderer_state.default_cmd;
-			render_command__set_texcube(cmd, tex_slot, tex_id);
-		}
+                void renderer_set_texture_cube(c_str slot_name, const texture_cube_t& tex_id)
+                {
+                        auto& cmd = g_renderer_state.default_cmd;
+                        core::hash_t slot_hash{};
+                        core::string_pool_intern(slot_name, &slot_hash);
+                        render_command__set_texcube(cmd, slot_hash, tex_id);
+                }
 
-		void renderer_set_texture_array(const u8& tex_slot, const texture_array_t& tex_id)
-		{
-			auto& cmd = g_renderer_state.default_cmd;
-			render_command__set_texarray(cmd, tex_slot, tex_id);
-		}
+                void renderer_set_texture_array(c_str slot_name, const texture_array_t& tex_id)
+                {
+                        auto& cmd = g_renderer_state.default_cmd;
+                        core::hash_t slot_hash{};
+                        core::string_pool_intern(slot_name, &slot_hash);
+                        render_command__set_texarray(cmd, slot_hash, tex_id);
+                }
+
+                void renderer_set_texture_2d(core::hash_t slot, const texture_2d_t& tex_id)
+                {
+                        auto& cmd = g_renderer_state.default_cmd;
+                        render_command__set_tex2d(cmd, slot, tex_id);
+                }
+
+                void renderer_set_texture_3d(core::hash_t slot, const texture_3d_t& tex_id)
+                {
+                        auto& cmd = g_renderer_state.default_cmd;
+                        render_command__set_tex3d(cmd, slot, tex_id);
+                }
+
+                void renderer_set_texture_cube(core::hash_t slot, const texture_cube_t& tex_id)
+                {
+                        auto& cmd = g_renderer_state.default_cmd;
+                        render_command__set_texcube(cmd, slot, tex_id);
+                }
+
+                void renderer_set_texture_array(core::hash_t slot, const texture_array_t& tex_id)
+                {
+                        auto& cmd = g_renderer_state.default_cmd;
+                        render_command__set_texarray(cmd, slot, tex_id);
+                }
 
 		void renderer_set_viewport(const math::urect& rect)
 		{

--- a/source/rengine/graphics/renderer.h
+++ b/source/rengine/graphics/renderer.h
@@ -43,10 +43,14 @@ namespace rengine {
 		R_EXPORT void renderer_set_ibuffer(const index_buffer_t& buffer, u64 offset = 0);
 		R_EXPORT void renderer_set_render_target(const render_target_t& rt_id, const render_target_t& depth_id = no_render_target);
 		R_EXPORT void renderer_set_render_targets(const render_target_t* render_targets, const u8& num_rts, const render_target_t& depth_id = no_render_target);
-		R_EXPORT void renderer_set_texture_2d(const u8& tex_slot, const texture_2d_t& tex_id);
-		R_EXPORT void renderer_set_texture_3d(const u8& tex_slot, const texture_3d_t& tex_id);
-		R_EXPORT void renderer_set_texture_cube(const u8& tex_slot, const texture_cube_t& tex_id);
-		R_EXPORT void renderer_set_texture_array(const u8& tex_slot, const texture_array_t& tex_id);
+                R_EXPORT void renderer_set_texture_2d(c_str slot_name, const texture_2d_t& tex_id);
+                R_EXPORT void renderer_set_texture_3d(c_str slot_name, const texture_3d_t& tex_id);
+                R_EXPORT void renderer_set_texture_cube(c_str slot_name, const texture_cube_t& tex_id);
+                R_EXPORT void renderer_set_texture_array(c_str slot_name, const texture_array_t& tex_id);
+                R_EXPORT void renderer_set_texture_2d(core::hash_t slot, const texture_2d_t& tex_id);
+                R_EXPORT void renderer_set_texture_3d(core::hash_t slot, const texture_3d_t& tex_id);
+                R_EXPORT void renderer_set_texture_cube(core::hash_t slot, const texture_cube_t& tex_id);
+                R_EXPORT void renderer_set_texture_array(core::hash_t slot, const texture_array_t& tex_id);
 
 		R_EXPORT void renderer_set_viewport(const math::urect& rect);
 		R_EXPORT void renderer_set_topology(const primitive_topology& topology);


### PR DESCRIPTION
## Summary
- add string_pool hash for texture slot functions
- update renderer texture APIs to use hashed names instead of u8 slots
- implement texture assignment internals
- adapt ImGui manager for new API

## Testing
- `cmake -S . -B build` *(fails: Could NOT find OpenGL)*

------
https://chatgpt.com/codex/tasks/task_e_6843170d56648327a427012084f6bee9