### PR TITLE
Fix texture binding in SRB

### DIFF
--- a/source/rengine/graphics/render_command_private.cpp
+++ b/source/rengine/graphics/render_command_private.cpp
@@ -2,6 +2,7 @@
 #include "./pipeline_state_manager.h"
 #include "./render_target_manager.h"
 #include "./srb_manager.h"
+#include "./texture_manager.h"
 #include "./shader_manager_private.h"
 
 #include "../strings.h"
@@ -93,16 +94,18 @@ namespace rengine {
 				sizeof(srb_mgr_resource_desc) * data.resources.size()
 			);
 
-			for (const auto& it : data.resources) {
-				const auto& res = it.second;
-				auto& srb_res = srb_desc.resources[srb_desc.num_resources];
-				srb_res.name = res.resource.name;
-				srb_res.id = res.tex_id;
-				srb_res.type = res.type;
-				++srb_desc.num_resources;
-			}
-			data.srb = srb_mgr_create({ data.pipeline_state, null, 0 });
-		}
+                        for (const auto& it : data.resources) {
+                                const auto& res = it.second;
+                                auto& srb_res = srb_desc.resources[srb_desc.num_resources];
+                                srb_res.name = res.resource.name;
+                                srb_res.id = res.tex_id;
+                                srb_res.type = res.type;
+                                ++srb_desc.num_resources;
+                        }
+                        data.srb = srb_mgr_create(srb_desc);
+
+                        core::alloc_scratch_pop(sizeof(srb_mgr_resource_desc) * data.resources.size());
+                }
 
 		void render_command__build_hash(render_command_data& data)
 		{
@@ -165,12 +168,12 @@ namespace rengine {
 			if (cmd.program == no_shader_program)
 				return;
 
-			auto hash = (core::hash_t)cmd.textures.size();
-			for (const auto& it : cmd.textures) {
-				const auto& res = it.second;
-				hash = core::hash_combine(hash, res.resource.id);
-				hash = core::hash_combine(hash, (u32)res.type);
-			}
+                        auto hash = (core::hash_t)cmd.resources.size();
+                        for (const auto& it : cmd.resources) {
+                                const auto& res = it.second;
+                                hash = core::hash_combine(hash, res.resource.id);
+                                hash = core::hash_combine(hash, (u32)res.type);
+                        }
 
 			cmd.hashes.textures = hash;
 		}
@@ -294,8 +297,8 @@ namespace rengine {
 
 		void render_command__set_texcube(render_command_data& cmd, const core::hash_t& slot, const texture_cube_t& id)
 		{
-			if (no_texture_cube = id)
-				return;
+                        if (no_texture_cube == id)
+                                return;
 
 			render_command_resource res{};
 			res.type = resource_type::texcube;
@@ -320,10 +323,10 @@ namespace rengine {
 
 		void render_command__unset_tex(render_command_data& cmd, const core::hash_t& slot)
 		{
-			const auto& it = cmd.textures.find_as(slot);
-			if (cmd.textures.end() == it)
-				return;
-			cmd.textures.erase(it);
+                        const auto& it = cmd.resources.find_as(slot);
+                        if (cmd.resources.end() == it)
+                                return;
+                        cmd.resources.erase(it);
 		}
 
 		void render_command__set_viewport(render_command_data& cmd, const math::urect& rect)

--- a/source/rengine/graphics/srb_manager_private.cpp
+++ b/source/rengine/graphics/srb_manager_private.cpp
@@ -1,6 +1,7 @@
 #include "./srb_manager_private.h"
 #include "./render_target_manager.h"
 #include "./buffer_manager_private.h"
+#include "./texture_manager_private.h"
 
 #include "../core/hash.h"
 #include "../exceptions.h"
@@ -66,27 +67,52 @@ namespace rengine {
 			*output = state.entries[id].handle;
 		}
 
-		Diligent::IDeviceObject* srb_mgr__get_device_obj(const srb_mgr_resource_desc& resource)
-		{
-			Diligent::IDeviceObject* result = null;
-			switch (resource.type)
-			{
-			case srb_mgr_resource_type::tex2d:
-				throw not_implemented_exception();
-				break;
-			case srb_mgr_resource_type::tex3d:
-				throw not_implemented_exception();
-				break;
-			case srb_mgr_resource_type::texcube:
-				throw not_implemented_exception();
-				break;
-			case srb_mgr_resource_type::texarray:
-				throw not_implemented_exception();
-				break;
-			case srb_mgr_resource_type::rt:
-				render_target_mgr_get_handlers(resource.id, reinterpret_cast<ptr*>(&result), null);
-				break;
-			}
+                Diligent::IDeviceObject* srb_mgr__get_device_obj(const srb_mgr_resource_desc& resource)
+                {
+                        Diligent::IDeviceObject* result = null;
+
+                        switch (resource.type)
+                        {
+                        case resource_type::tex2d:
+                        {
+                                Diligent::ITexture* tex = null;
+                                texture_mgr__get_internal_handle(texture_type::tex2d, resource.id, &tex);
+                                if (tex)
+                                        result = tex->GetDefaultView(Diligent::TEXTURE_VIEW_SHADER_RESOURCE);
+                        }
+                                break;
+                        case resource_type::tex3d:
+                        {
+                                Diligent::ITexture* tex = null;
+                                texture_mgr__get_internal_handle(texture_type::tex3d, resource.id, &tex);
+                                if (tex)
+                                        result = tex->GetDefaultView(Diligent::TEXTURE_VIEW_SHADER_RESOURCE);
+                        }
+                                break;
+                        case resource_type::texcube:
+                        {
+                                Diligent::ITexture* tex = null;
+                                texture_mgr__get_internal_handle(texture_type::texcube, resource.id, &tex);
+                                if (tex)
+                                        result = tex->GetDefaultView(Diligent::TEXTURE_VIEW_SHADER_RESOURCE);
+                        }
+                                break;
+                        case resource_type::texarray:
+                        {
+                                Diligent::ITexture* tex = null;
+                                texture_mgr__get_internal_handle(texture_type::texarray, resource.id, &tex);
+                                if (tex)
+                                        result = tex->GetDefaultView(Diligent::TEXTURE_VIEW_SHADER_RESOURCE);
+                        }
+                                break;
+                        case resource_type::rt:
+                                render_target_mgr_get_handlers(resource.id, reinterpret_cast<ptr*>(&result), null);
+                                if(result)
+                                        result = reinterpret_cast<Diligent::ITexture*>(result)->GetDefaultView(Diligent::TEXTURE_VIEW_SHADER_RESOURCE);
+                                break;
+                        default:
+                                break;
+                        }
 
 			return result;
 		}

--- a/source/rengine/graphics/texture_manager_private.cpp
+++ b/source/rengine/graphics/texture_manager_private.cpp
@@ -94,8 +94,8 @@ namespace rengine {
 			}
 		}
 
-		Diligent::ITexture* texture_mgr__create(Diligent::TextureDesc& desc, Diligent::TextureData& data, bool gen_mipmap)
-		{
+                Diligent::ITexture* texture_mgr__create(Diligent::TextureDesc& desc, Diligent::TextureData& data, bool gen_mipmap)
+                {
 			auto device = g_graphics_state.device;
 			auto ctx = g_graphics_state.contexts[0];
 			Diligent::ITexture* texture = nullptr;
@@ -106,9 +106,41 @@ namespace rengine {
 					fmt::format(strings::exceptions::g_texture_mgr_failed_to_create_tex, desc.Name).c_str()
 				);
 
-			if(gen_mipmap)
-				ctx->GenerateMips(texture->GetDefaultView(Diligent::TEXTURE_VIEW_SHADER_RESOURCE));
-			return texture;
-		}
-	}
+                        if(gen_mipmap)
+                                ctx->GenerateMips(texture->GetDefaultView(Diligent::TEXTURE_VIEW_SHADER_RESOURCE));
+                        return texture;
+                }
+
+                void texture_mgr__get_internal_handle(texture_type type, u16 id, Diligent::ITexture** output)
+                {
+                        if (!output)
+                                return;
+
+                        *output = null;
+
+                        auto& state = g_texture_mgr_state;
+
+                        switch (type)
+                        {
+                        case texture_type::tex2d:
+                                if (id != no_texture_2d)
+                                        *output = state.textures_2d[id].value.handler;
+                                break;
+                        case texture_type::tex3d:
+                                if (id != no_texture_3d)
+                                        *output = state.textures_3d[id].value.handler;
+                                break;
+                        case texture_type::texcube:
+                                if (id != no_texture_cube)
+                                        *output = state.textures_cube[id].value.handler;
+                                break;
+                        case texture_type::texarray:
+                                if (id != no_texture_array)
+                                        *output = state.textures_array[id].value.handler;
+                                break;
+                        default:
+                                break;
+                        }
+                }
+        }
 }

--- a/source/rengine/graphics/texture_manager_private.h
+++ b/source/rengine/graphics/texture_manager_private.h
@@ -54,6 +54,8 @@ namespace rengine {
 		void texture_mgr__fill_tex2d_desc(const texture_create_desc<texture_2d_size>& desc, Diligent::TextureDesc& out_desc);
 		void texture_mgr__fill_subres(const texture_data_desc& data, Diligent::TextureSubResData* subres);
 
-		Diligent::ITexture* texture_mgr__create(Diligent::TextureDesc& desc, Diligent::TextureData& data, bool gen_mipmap);
-	}
+                Diligent::ITexture* texture_mgr__create(Diligent::TextureDesc& desc, Diligent::TextureData& data, bool gen_mipmap);
+
+                void texture_mgr__get_internal_handle(texture_type type, u16 id, Diligent::ITexture** output);
+        }
 }


### PR DESCRIPTION
## Summary
- wire up texture resources when building SRBs
- provide access to texture device objects
- bind textures correctly in SRB creation logic
- fix texture cube equality check and resource maps

## Testing
- `cmake -G "Unix Makefiles" ..` *(fails: Could NOT find OpenGL)*

------
https://chatgpt.com/codex/tasks/task_e_6844debba21c8327b83728053fc0ad5a