### PR TITLE
Fix texture binding in SRB

### DIFF
--- a/source/rengine/graphics/drawing_private.cpp
+++ b/source/rengine/graphics/drawing_private.cpp
@@ -114,30 +114,37 @@ namespace rengine {
 			shader_desc.source_code = strings::graphics::shaders::g_drawing_ps;
 			shader_desc.source_code_length = strlen(shader_desc.source_code);
 
-			state.pixel_shader = shader_mgr_create(shader_desc);
-		}
+                        state.pixel_shader = shader_mgr_create(shader_desc);
+
+                        shader_program_create_desc program_desc{};
+                        program_desc.desc.pixel_shader = state.pixel_shader;
+                        program_desc.desc.vertex_shader = state.vertex_shader[0];
+                        state.program[0] = shader_mgr_create_program(program_desc);
+
+                        program_desc.desc.vertex_shader = state.vertex_shader[1];
+                        state.program[1] = shader_mgr_create_program(program_desc);
+                }
 
 		void drawing__prewarm_pipelines()
 		{
-			graphics_pipeline_state_create create_desc = {};
-			create_desc.name = strings::graphics::g_drawing_pipeline_name;
-			create_desc.pixel_shader = g_drawing_state.pixel_shader;
-			create_desc.topology = primitive_topology::triangle_list;
-			create_desc.num_render_targets = 1;
-			create_desc.render_target_formats[0] = get_default_backbuffer_format();
-			create_desc.depth_stencil_format = get_default_depthbuffer_format();
-			create_desc.vertex_elements = (u32)vertex_elements::position | (u32)vertex_elements::color;
+                        graphics_pipeline_state_create create_desc = {};
+                        create_desc.name = strings::graphics::g_drawing_pipeline_name;
+                        create_desc.topology = primitive_topology::triangle_list;
+                        create_desc.num_render_targets = 1;
+                        create_desc.render_target_formats[0] = get_default_backbuffer_format();
+                        create_desc.depth_stencil_format = get_default_depthbuffer_format();
+                        create_desc.vertex_elements = (u32)vertex_elements::position | (u32)vertex_elements::color;
 
-			for (u32 i = 0; i < 2; ++i) {
-				create_desc.vertex_shader = g_drawing_state.vertex_shader[i];
-				for (u32 i = 0; i < (u8)primitive_topology::line_strip; ++i) {
-					create_desc.topology = (primitive_topology)i;
-					create_desc.wireframe = false;
-					pipeline_state_mgr_create_graphics(create_desc);
-					create_desc.wireframe = true;
-					pipeline_state_mgr_create_graphics(create_desc);
-				}
-			}
+                        for (u32 i = 0; i < 2; ++i) {
+                                create_desc.shader_program = g_drawing_state.program[i];
+                                for (u32 j = 0; j < (u8)primitive_topology::line_strip; ++j) {
+                                        create_desc.topology = (primitive_topology)j;
+                                        create_desc.wireframe = false;
+                                        pipeline_state_mgr_create_graphics(create_desc);
+                                        create_desc.wireframe = true;
+                                        pipeline_state_mgr_create_graphics(create_desc);
+                                }
+                        }
 		}
 
 		void drawing__check_buffer_requirements()
@@ -200,10 +207,9 @@ namespace rengine {
 			renderer_set_depth_enabled(true);
 			renderer_set_wireframe(false);
 			renderer_set_cull_mode(cull_mode::clock_wise);
-			renderer_set_vertex_shader(g_drawing_state.vertex_shader[1]);
-			renderer_set_pixel_shader(g_drawing_state.pixel_shader);
-			renderer_set_vertex_elements((u32)vertex_elements::position | (u32)vertex_elements::color | (u32)vertex_elements::uv);
-			renderer_draw({ (u32)state.triangles.size() * 3 });
+                        renderer_set_program(g_drawing_state.program[1]);
+                        renderer_set_vertex_elements((u32)vertex_elements::position | (u32)vertex_elements::color | (u32)vertex_elements::uv);
+                        renderer_draw({ (u32)state.triangles.size() * 3 });
 		}
 
 		void drawing__draw_lines()
@@ -216,10 +222,9 @@ namespace rengine {
 			renderer_set_depth_enabled(true);
 			renderer_set_wireframe(false);
 			renderer_set_cull_mode(cull_mode::clock_wise);
-			renderer_set_vertex_shader(g_drawing_state.vertex_shader[0]);
-			renderer_set_pixel_shader(g_drawing_state.pixel_shader);
-			renderer_set_vertex_elements((u32)vertex_elements::position | (u32)vertex_elements::color);
-			renderer_draw({ (u32)g_drawing_state.lines.size() * 2 });
+                        renderer_set_program(g_drawing_state.program[0]);
+                        renderer_set_vertex_elements((u32)vertex_elements::position | (u32)vertex_elements::color);
+                        renderer_draw({ (u32)g_drawing_state.lines.size() * 2 });
 		}
 
 		void drawing__draw_points()
@@ -235,10 +240,9 @@ namespace rengine {
 			renderer_set_depth_enabled(true);
 			renderer_set_wireframe(false);
 			renderer_set_cull_mode(cull_mode::clock_wise);
-			renderer_set_vertex_shader(g_drawing_state.vertex_shader[0]);
-			renderer_set_pixel_shader(g_drawing_state.pixel_shader);
-			renderer_set_vertex_elements((u32)vertex_elements::position | (u32)vertex_elements::color);
-			renderer_draw({ (u32)g_drawing_state.points.size() });
+                        renderer_set_program(g_drawing_state.program[0]);
+                        renderer_set_vertex_elements((u32)vertex_elements::position | (u32)vertex_elements::color);
+                        renderer_draw({ (u32)g_drawing_state.points.size() });
 		}
 
 		void drawing__compute_transform()

--- a/source/rengine/graphics/drawing_private.cpp
+++ b/source/rengine/graphics/drawing_private.cpp
@@ -97,31 +97,34 @@ namespace rengine {
 		{
 			auto& state = g_drawing_state;
 
-			shader_create_desc shader_desc = {};
-			shader_desc.name = strings::graphics::g_drawing_vshader_name;
-			shader_desc.type = shader_type::vertex;
-			shader_desc.source_code = strings::graphics::shaders::g_drawing_vs;
-			shader_desc.source_code_length = strlen(shader_desc.source_code);
-			shader_desc.vertex_elements = (u32)vertex_elements::position | (u32)vertex_elements::color;
-			
-			state.vertex_shader[0] = shader_mgr_create(shader_desc);
-			shader_desc.vertex_elements |= (u32)vertex_elements::uv;
-			state.vertex_shader[1] = shader_mgr_create(shader_desc);
+                        shader_create_desc shader_desc = {};
+                        shader_t vertex_shader[2]{ no_shader };
+                        shader_t pixel_shader{ no_shader };
 
-			shader_desc.num_macros = 0;
-			shader_desc.name = strings::graphics::g_drawing_pshader_name;
-			shader_desc.type = shader_type::pixel;
-			shader_desc.source_code = strings::graphics::shaders::g_drawing_ps;
-			shader_desc.source_code_length = strlen(shader_desc.source_code);
+                        shader_desc.name = strings::graphics::g_drawing_vshader_name;
+                        shader_desc.type = shader_type::vertex;
+                        shader_desc.source_code = strings::graphics::shaders::g_drawing_vs;
+                        shader_desc.source_code_length = strlen(shader_desc.source_code);
+                        shader_desc.vertex_elements = (u32)vertex_elements::position | (u32)vertex_elements::color;
 
-                        state.pixel_shader = shader_mgr_create(shader_desc);
+                        vertex_shader[0] = shader_mgr_create(shader_desc);
+                        shader_desc.vertex_elements |= (u32)vertex_elements::uv;
+                        vertex_shader[1] = shader_mgr_create(shader_desc);
+
+                        shader_desc.num_macros = 0;
+                        shader_desc.name = strings::graphics::g_drawing_pshader_name;
+                        shader_desc.type = shader_type::pixel;
+                        shader_desc.source_code = strings::graphics::shaders::g_drawing_ps;
+                        shader_desc.source_code_length = strlen(shader_desc.source_code);
+
+                        pixel_shader = shader_mgr_create(shader_desc);
 
                         shader_program_create_desc program_desc{};
-                        program_desc.desc.pixel_shader = state.pixel_shader;
-                        program_desc.desc.vertex_shader = state.vertex_shader[0];
+                        program_desc.desc.pixel_shader = pixel_shader;
+                        program_desc.desc.vertex_shader = vertex_shader[0];
                         state.program[0] = shader_mgr_create_program(program_desc);
 
-                        program_desc.desc.vertex_shader = state.vertex_shader[1];
+                        program_desc.desc.vertex_shader = vertex_shader[1];
                         state.program[1] = shader_mgr_create_program(program_desc);
                 }
 

--- a/source/rengine/graphics/drawing_private.h
+++ b/source/rengine/graphics/drawing_private.h
@@ -55,9 +55,7 @@ namespace rengine {
 			vertex_buffer_t vertex_buffer{ no_vertex_buffer };
 			constant_buffer_t constant_buffer{ no_constant_buffer };
 
-                        shader_t vertex_shader[2]{ no_shader };
-                        shader_t pixel_shader{ no_shader };
-                        shader_program_t program[2]{ no_shader_program, no_shader_program };
+                       shader_program_t program[2]{ no_shader_program, no_shader_program };
 
 			u32 vertex_buffer_size{ 0 };
 		};

--- a/source/rengine/graphics/drawing_private.h
+++ b/source/rengine/graphics/drawing_private.h
@@ -55,8 +55,9 @@ namespace rengine {
 			vertex_buffer_t vertex_buffer{ no_vertex_buffer };
 			constant_buffer_t constant_buffer{ no_constant_buffer };
 
-			shader_t vertex_shader[2]{ no_shader };
-			shader_t pixel_shader{ no_shader };
+                        shader_t vertex_shader[2]{ no_shader };
+                        shader_t pixel_shader{ no_shader };
+                        shader_program_t program[2]{ no_shader_program, no_shader_program };
 
 			u32 vertex_buffer_size{ 0 };
 		};

--- a/source/rengine/graphics/imgui_manager_private.cpp
+++ b/source/rengine/graphics/imgui_manager_private.cpp
@@ -119,8 +119,13 @@ namespace rengine {
 			shader_desc.source_code = strings::graphics::shaders::g_drawing_ps;
 			shader_desc.source_code_length = strlen(shader_desc.source_code);
 
-			state.pixel_shader = shader_mgr_create(shader_desc);
-		}
+                        state.pixel_shader = shader_mgr_create(shader_desc);
+
+                        shader_program_create_desc program_desc{};
+                        program_desc.desc.vertex_shader = state.vertex_shader;
+                        program_desc.desc.pixel_shader = state.pixel_shader;
+                        state.program = shader_mgr_create_program(program_desc);
+                }
 
 		c_str imgui_manager__get_clipboard_text(ImGuiContext* ctx)
 		{
@@ -304,9 +309,8 @@ namespace rengine {
 			renderer_set_vbuffer(state.vertex_buffer, 0);
 			renderer_set_ibuffer(state.index_buffer, 0);
 			renderer_set_vertex_elements((u32)vertex_elements::position | (u32)vertex_elements::uv | (u32)vertex_elements::color);
-			renderer_set_vertex_shader(state.vertex_shader);
-			renderer_set_pixel_shader(state.pixel_shader);
-			renderer_set_cull_mode(cull_mode::none);
+                        renderer_set_program(state.program);
+                        renderer_set_cull_mode(cull_mode::none);
 			renderer_set_topology(primitive_topology::triangle_list);
 			renderer_set_wireframe(false);
 			renderer_set_depth_enabled(true);

--- a/source/rengine/graphics/imgui_manager_private.h
+++ b/source/rengine/graphics/imgui_manager_private.h
@@ -15,8 +15,9 @@ namespace rengine {
 			SDL_Cursor* last_cursor{ null };
 
 			texture_2d_t font_tex{ UINT16_MAX };
-			shader_t vertex_shader{ no_shader };
-			shader_t pixel_shader{ no_shader };
+                        shader_t vertex_shader{ no_shader };
+                        shader_t pixel_shader{ no_shader };
+                        shader_program_t program{ no_shader_program };
 
 			vertex_buffer_t vertex_buffer{ no_vertex_buffer };
 			index_buffer_t index_buffer{ no_index_buffer };

--- a/source/rengine/graphics/render_command_private.cpp
+++ b/source/rengine/graphics/render_command_private.cpp
@@ -2,6 +2,7 @@
 #include "./pipeline_state_manager.h"
 #include "./render_target_manager.h"
 #include "./srb_manager.h"
+#include "./texture_manager.h"
 #include "./shader_manager_private.h"
 
 #include "../strings.h"
@@ -93,16 +94,18 @@ namespace rengine {
 				sizeof(srb_mgr_resource_desc) * data.resources.size()
 			);
 
-			for (const auto& it : data.resources) {
-				const auto& res = it.second;
-				auto& srb_res = srb_desc.resources[srb_desc.num_resources];
-				srb_res.name = res.resource.name;
-				srb_res.id = res.tex_id;
-				srb_res.type = res.type;
-				++srb_desc.num_resources;
-			}
-			data.srb = srb_mgr_create({ data.pipeline_state, null, 0 });
-		}
+                        for (const auto& it : data.resources) {
+                                const auto& res = it.second;
+                                auto& srb_res = srb_desc.resources[srb_desc.num_resources];
+                                srb_res.name = res.resource.name;
+                                srb_res.id = res.tex_id;
+                                srb_res.type = res.type;
+                                ++srb_desc.num_resources;
+                        }
+                        data.srb = srb_mgr_create(srb_desc);
+
+                        core::alloc_scratch_pop(sizeof(srb_mgr_resource_desc) * data.resources.size());
+                }
 
 		void render_command__build_hash(render_command_data& data)
 		{
@@ -165,12 +168,12 @@ namespace rengine {
 			if (cmd.program == no_shader_program)
 				return;
 
-			auto hash = (core::hash_t)cmd.textures.size();
-			for (const auto& it : cmd.textures) {
-				const auto& res = it.second;
-				hash = core::hash_combine(hash, res.resource.id);
-				hash = core::hash_combine(hash, (u32)res.type);
-			}
+                        auto hash = (core::hash_t)cmd.resources.size();
+                        for (const auto& it : cmd.resources) {
+                                const auto& res = it.second;
+                                hash = core::hash_combine(hash, res.resource.id);
+                                hash = core::hash_combine(hash, (u32)res.type);
+                        }
 
 			cmd.hashes.textures = hash;
 		}
@@ -294,8 +297,8 @@ namespace rengine {
 
 		void render_command__set_texcube(render_command_data& cmd, const core::hash_t& slot, const texture_cube_t& id)
 		{
-			if (no_texture_cube = id)
-				return;
+                        if (no_texture_cube == id)
+                                return;
 
 			render_command_resource res{};
 			res.type = resource_type::texcube;
@@ -320,10 +323,10 @@ namespace rengine {
 
 		void render_command__unset_tex(render_command_data& cmd, const core::hash_t& slot)
 		{
-			const auto& it = cmd.textures.find_as(slot);
-			if (cmd.textures.end() == it)
-				return;
-			cmd.textures.erase(it);
+                        const auto& it = cmd.resources.find_as(slot);
+                        if (cmd.resources.end() == it)
+                                return;
+                        cmd.resources.erase(it);
 		}
 
 		void render_command__set_viewport(render_command_data& cmd, const math::urect& rect)

--- a/source/rengine/graphics/srb_manager_private.cpp
+++ b/source/rengine/graphics/srb_manager_private.cpp
@@ -1,6 +1,7 @@
 #include "./srb_manager_private.h"
 #include "./render_target_manager.h"
 #include "./buffer_manager_private.h"
+#include "./texture_manager_private.h"
 
 #include "../core/hash.h"
 #include "../exceptions.h"
@@ -66,27 +67,52 @@ namespace rengine {
 			*output = state.entries[id].handle;
 		}
 
-		Diligent::IDeviceObject* srb_mgr__get_device_obj(const srb_mgr_resource_desc& resource)
-		{
-			Diligent::IDeviceObject* result = null;
-			switch (resource.type)
-			{
-			case srb_mgr_resource_type::tex2d:
-				throw not_implemented_exception();
-				break;
-			case srb_mgr_resource_type::tex3d:
-				throw not_implemented_exception();
-				break;
-			case srb_mgr_resource_type::texcube:
-				throw not_implemented_exception();
-				break;
-			case srb_mgr_resource_type::texarray:
-				throw not_implemented_exception();
-				break;
-			case srb_mgr_resource_type::rt:
-				render_target_mgr_get_handlers(resource.id, reinterpret_cast<ptr*>(&result), null);
-				break;
-			}
+                Diligent::IDeviceObject* srb_mgr__get_device_obj(const srb_mgr_resource_desc& resource)
+                {
+                        Diligent::IDeviceObject* result = null;
+
+                        switch (resource.type)
+                        {
+                        case resource_type::tex2d:
+                        {
+                                Diligent::ITexture* tex = null;
+                                texture_mgr__get_internal_handle(texture_type::tex2d, resource.id, &tex);
+                                if (tex)
+                                        result = tex->GetDefaultView(Diligent::TEXTURE_VIEW_SHADER_RESOURCE);
+                        }
+                                break;
+                        case resource_type::tex3d:
+                        {
+                                Diligent::ITexture* tex = null;
+                                texture_mgr__get_internal_handle(texture_type::tex3d, resource.id, &tex);
+                                if (tex)
+                                        result = tex->GetDefaultView(Diligent::TEXTURE_VIEW_SHADER_RESOURCE);
+                        }
+                                break;
+                        case resource_type::texcube:
+                        {
+                                Diligent::ITexture* tex = null;
+                                texture_mgr__get_internal_handle(texture_type::texcube, resource.id, &tex);
+                                if (tex)
+                                        result = tex->GetDefaultView(Diligent::TEXTURE_VIEW_SHADER_RESOURCE);
+                        }
+                                break;
+                        case resource_type::texarray:
+                        {
+                                Diligent::ITexture* tex = null;
+                                texture_mgr__get_internal_handle(texture_type::texarray, resource.id, &tex);
+                                if (tex)
+                                        result = tex->GetDefaultView(Diligent::TEXTURE_VIEW_SHADER_RESOURCE);
+                        }
+                                break;
+                        case resource_type::rt:
+                                render_target_mgr_get_handlers(resource.id, reinterpret_cast<ptr*>(&result), null);
+                                if(result)
+                                        result = reinterpret_cast<Diligent::ITexture*>(result)->GetDefaultView(Diligent::TEXTURE_VIEW_SHADER_RESOURCE);
+                                break;
+                        default:
+                                break;
+                        }
 
 			return result;
 		}

--- a/source/rengine/graphics/texture_manager_private.cpp
+++ b/source/rengine/graphics/texture_manager_private.cpp
@@ -94,8 +94,8 @@ namespace rengine {
 			}
 		}
 
-		Diligent::ITexture* texture_mgr__create(Diligent::TextureDesc& desc, Diligent::TextureData& data, bool gen_mipmap)
-		{
+                Diligent::ITexture* texture_mgr__create(Diligent::TextureDesc& desc, Diligent::TextureData& data, bool gen_mipmap)
+                {
 			auto device = g_graphics_state.device;
 			auto ctx = g_graphics_state.contexts[0];
 			Diligent::ITexture* texture = nullptr;
@@ -106,9 +106,41 @@ namespace rengine {
 					fmt::format(strings::exceptions::g_texture_mgr_failed_to_create_tex, desc.Name).c_str()
 				);
 
-			if(gen_mipmap)
-				ctx->GenerateMips(texture->GetDefaultView(Diligent::TEXTURE_VIEW_SHADER_RESOURCE));
-			return texture;
-		}
-	}
+                        if(gen_mipmap)
+                                ctx->GenerateMips(texture->GetDefaultView(Diligent::TEXTURE_VIEW_SHADER_RESOURCE));
+                        return texture;
+                }
+
+                void texture_mgr__get_internal_handle(texture_type type, u16 id, Diligent::ITexture** output)
+                {
+                        if (!output)
+                                return;
+
+                        *output = null;
+
+                        auto& state = g_texture_mgr_state;
+
+                        switch (type)
+                        {
+                        case texture_type::tex2d:
+                                if (id != no_texture_2d)
+                                        *output = state.textures_2d[id].value.handler;
+                                break;
+                        case texture_type::tex3d:
+                                if (id != no_texture_3d)
+                                        *output = state.textures_3d[id].value.handler;
+                                break;
+                        case texture_type::texcube:
+                                if (id != no_texture_cube)
+                                        *output = state.textures_cube[id].value.handler;
+                                break;
+                        case texture_type::texarray:
+                                if (id != no_texture_array)
+                                        *output = state.textures_array[id].value.handler;
+                                break;
+                        default:
+                                break;
+                        }
+                }
+        }
 }

--- a/source/rengine/graphics/texture_manager_private.h
+++ b/source/rengine/graphics/texture_manager_private.h
@@ -54,6 +54,8 @@ namespace rengine {
 		void texture_mgr__fill_tex2d_desc(const texture_create_desc<texture_2d_size>& desc, Diligent::TextureDesc& out_desc);
 		void texture_mgr__fill_subres(const texture_data_desc& data, Diligent::TextureSubResData* subres);
 
-		Diligent::ITexture* texture_mgr__create(Diligent::TextureDesc& desc, Diligent::TextureData& data, bool gen_mipmap);
-	}
+                Diligent::ITexture* texture_mgr__create(Diligent::TextureDesc& desc, Diligent::TextureData& data, bool gen_mipmap);
+
+                void texture_mgr__get_internal_handle(texture_type type, u16 id, Diligent::ITexture** output);
+        }
 }


### PR DESCRIPTION
## Summary
- wire up texture resources when building SRBs
- provide access to texture device objects
- bind textures correctly in SRB creation logic
- fix texture cube equality check and resource maps
- drop deprecated shader binding calls
- use shader programs for drawing and ImGui

## Testing
- `cmake -G "Unix Makefiles" ..` *(fails: Could NOT find OpenGL)*

------
https://chatgpt.com/codex/tasks/task_e_6844debba21c8327b83728053fc0ad5a