### PR TITLE
Add scissor rectangles support

### DIFF
--- a/source/rengine/defines.h
+++ b/source/rengine/defines.h
@@ -11,6 +11,9 @@
 
 #define IO_MAX_LOG_OBJECTS 0xFF
 
+// Max number of scissors allowed per render command
+#define GRAPHICS_MAX_SCISSORS 4
+
 #define GRAPHICS_MAX_RENDER_TARGETS 4
 #define GRAPHICS_MAX_VBUFFERS 2
 #define GRAPHICS_MAX_RENDER_COMMANDS 0xFF

--- a/source/rengine/graphics/imgui_manager_private.cpp
+++ b/source/rengine/graphics/imgui_manager_private.cpp
@@ -354,8 +354,12 @@ namespace rengine {
 					if (clip_max.x <= clip_min.x || clip_max.y <= clip_min.y)
 						continue;
 
-					// TODO: implement scissors
-					const auto tex = cmd->GetTexID();
+                                        math::rect scissor_rect{};
+                                        scissor_rect.position = { clip_min.x, clip_min.y };
+                                        scissor_rect.size = { clip_max.x - clip_min.x, clip_max.y - clip_min.y };
+                                        renderer_set_scissor_rect(scissor_rect);
+                                        renderer_set_scissors(true);
+                                        const auto tex = cmd->GetTexID();
 					renderer_set_texture_2d("g_texture", tex);
 
 					draw_indexed_desc draw_desc = {};

--- a/source/rengine/graphics/render_command.cpp
+++ b/source/rengine/graphics/render_command.cpp
@@ -165,12 +165,26 @@ namespace rengine {
 			render_command__unset_tex(cmd, slot);
 		}
 
-		void render_command_set_viewport(const math::urect& rect)
-		{
-			ASSERT_RENDER_COMMAND_UPDATE();
-			auto& cmd = *g_render_command_state.curr_cmd;
-			render_command__set_viewport(cmd, rect);
-		}
+                void render_command_set_viewport(const math::urect& rect)
+                {
+                        ASSERT_RENDER_COMMAND_UPDATE();
+                        auto& cmd = *g_render_command_state.curr_cmd;
+                        render_command__set_viewport(cmd, rect);
+                }
+
+                void render_command_set_scissor_rect(const math::rect& rect)
+                {
+                        ASSERT_RENDER_COMMAND_UPDATE();
+                        auto& cmd = *g_render_command_state.curr_cmd;
+                        render_command__set_scissor_rect(cmd, rect);
+                }
+
+                void render_command_set_scissor_rects(const math::rect* rects, u8 num_rects)
+                {
+                        ASSERT_RENDER_COMMAND_UPDATE();
+                        auto& cmd = *g_render_command_state.curr_cmd;
+                        render_command__set_scissor_rects(cmd, rects, num_rects);
+                }
 
 		void render_command_set_topology(const primitive_topology& topology)
 		{

--- a/source/rengine/graphics/render_command.h
+++ b/source/rengine/graphics/render_command.h
@@ -25,8 +25,10 @@ namespace rengine {
 		void render_command_set_texcube(core::hash_t slot, const texture_cube_t& tex_id);
 		void render_command_set_texarray(core::hash_t slot, const texture_array_t& tex_id);
 		void render_command_unset_tex(core::hash_t slot);
-		void render_command_set_viewport(const math::urect& rect);
-		void render_command_set_topology(const primitive_topology& topology);
+                void render_command_set_viewport(const math::urect& rect);
+                void render_command_set_scissor_rect(const math::rect& rect);
+                void render_command_set_scissor_rects(const math::rect* rects, u8 num_rects);
+                void render_command_set_topology(const primitive_topology& topology);
 		void render_command_set_cull_mode(const cull_mode& cull);
 		void render_command_set_program(const shader_program_t& program_id);
 		void render_command_set_depth(const depth_desc& desc);

--- a/source/rengine/graphics/render_command_private.h
+++ b/source/rengine/graphics/render_command_private.h
@@ -16,8 +16,9 @@ namespace rengine {
 			core::hash_t vertex_buffers{ 0 };
 			core::hash_t vertex_buffer_offsets{ 0 };
 			core::hash_t index_buffer{ 0 };
-			core::hash_t viewport{ 0 };
-			core::hash_t graphics_state{ 0 };
+                       core::hash_t viewport{ 0 };
+                       core::hash_t scissors{ 0 };
+                       core::hash_t graphics_state{ 0 };
 			core::hash_t textures{ 0 };
 			core::hash_t depth_desc{ 0 };
 		};
@@ -42,8 +43,10 @@ namespace rengine {
 			u8 num_vertex_buffers{ 0 };
 
 			shader_program_t program{ no_shader_program };
-			hash_map<core::hash_t, render_command_resource> resources{};
-			math::urect viewport{};
+                       hash_map<core::hash_t, render_command_resource> resources{};
+                       math::urect viewport{};
+                       array<math::rect, GRAPHICS_MAX_SCISSORS> scissor_rects{};
+                       u8 num_scissors{ 0 };
 
 			primitive_topology topology{ primitive_topology::triangle_list };
 			cull_mode cull{ cull_mode::clock_wise };
@@ -84,9 +87,10 @@ namespace rengine {
 		void render_command__build_hash(render_command_data& data);
 		void render_command__build_vbuffer_hash(render_command_data& cmd);
 		void render_command__build_ibuffer_hash(render_command_data& cmd);
-		void render_command__build_rts_hash(render_command_data& cmd);
-		void render_command__build_viewport_hash(render_command_data& cmd);
-		void render_command__build_texture_hash(render_command_data& cmd);
+                void render_command__build_rts_hash(render_command_data& cmd);
+                void render_command__build_viewport_hash(render_command_data& cmd);
+                void render_command__build_scissor_hash(render_command_data& cmd);
+                void render_command__build_texture_hash(render_command_data& cmd);
 
 		void render_command__prepare_textures(render_command_data& cmd);
 
@@ -98,8 +102,10 @@ namespace rengine {
 		void render_command__set_texcube(render_command_data& cmd, const core::hash_t& slot, const texture_cube_t& id);
 		void render_command__set_texarray(render_command_data& cmd, const core::hash_t& slot, const texture_array_t& id);
 		void render_command__unset_tex(render_command_data& cmd, const core::hash_t& slot);
-		void render_command__set_viewport(render_command_data& cmd, const math::urect& rect);
-		void render_command__set_topology(render_command_data& cmd, const primitive_topology& topology);
+                void render_command__set_viewport(render_command_data& cmd, const math::urect& rect);
+                void render_command__set_scissor_rects(render_command_data& cmd, const math::rect* rects, u8 num_rects);
+                void render_command__set_scissor_rect(render_command_data& cmd, const math::rect& rect);
+                void render_command__set_topology(render_command_data& cmd, const primitive_topology& topology);
 		void render_command__set_cull(render_command_data& cmd, const cull_mode& cull);
 		void render_command__set_program(render_command_data& cmd, const shader_t& program_id);
 		void render_command__set_depth(render_command_data& cmd, const depth_desc& desc);

--- a/source/rengine/graphics/renderer.cpp
+++ b/source/rengine/graphics/renderer.cpp
@@ -90,8 +90,11 @@ namespace rengine {
 			if (cmd.hashes.index_buffer != state.context_state.prev_ibuffer_hash)
 				state.dirty_flags |= (u32)renderer_dirty_flags::index_buffer;
 
-			if (cmd.hashes.viewport != state.context_state.prev_viewport_hash)
-				state.dirty_flags |= (u32)renderer_dirty_flags::viewport;
+                        if (cmd.hashes.viewport != state.context_state.prev_viewport_hash)
+                                state.dirty_flags |= (u32)renderer_dirty_flags::viewport;
+
+                        if (cmd.hashes.scissors != state.context_state.prev_scissor_hash)
+                                state.dirty_flags |= (u32)renderer_dirty_flags::scissors;
 
 			if (cmd.pipeline_state != state.context_state.prev_pipeline_id)
 				state.dirty_flags |= (u32)renderer_dirty_flags::pipeline;
@@ -183,11 +186,23 @@ namespace rengine {
 			render_command__set_texarray(cmd, slot, tex_id);
 		}
 
-		void renderer_set_viewport(const math::urect& rect)
-		{
-			auto& cmd = g_renderer_state.default_cmd;
-			render_command__set_viewport(cmd, rect);
-		}
+                void renderer_set_viewport(const math::urect& rect)
+                {
+                        auto& cmd = g_renderer_state.default_cmd;
+                        render_command__set_viewport(cmd, rect);
+                }
+
+                void renderer_set_scissor_rect(const math::rect& rect)
+                {
+                        auto& cmd = g_renderer_state.default_cmd;
+                        render_command__set_scissor_rect(cmd, rect);
+                }
+
+                void renderer_set_scissor_rects(const math::rect* rects, u8 num_rects)
+                {
+                        auto& cmd = g_renderer_state.default_cmd;
+                        render_command__set_scissor_rects(cmd, rects, num_rects);
+                }
 
 		void renderer_set_topology(const primitive_topology& topology)
 		{

--- a/source/rengine/graphics/renderer.h
+++ b/source/rengine/graphics/renderer.h
@@ -50,8 +50,10 @@ namespace rengine {
         R_EXPORT void renderer_set_texture_cube(core::hash_t slot, const texture_cube_t& tex_id);
         R_EXPORT void renderer_set_texture_array(core::hash_t slot, const texture_array_t& tex_id);
 
-		R_EXPORT void renderer_set_viewport(const math::urect& rect);
-		R_EXPORT void renderer_set_topology(const primitive_topology& topology);
+                R_EXPORT void renderer_set_viewport(const math::urect& rect);
+                R_EXPORT void renderer_set_scissor_rect(const math::rect& rect);
+                R_EXPORT void renderer_set_scissor_rects(const math::rect* rects, u8 num_rects);
+                R_EXPORT void renderer_set_topology(const primitive_topology& topology);
                 R_EXPORT void renderer_set_cull_mode(const cull_mode& cull);
                 R_EXPORT void renderer_set_program(const shader_program_t& program_id);
                 R_EXPORT void renderer_set_depth(const depth_desc& desc);

--- a/source/rengine/graphics/renderer_private.h
+++ b/source/rengine/graphics/renderer_private.h
@@ -18,6 +18,7 @@ namespace rengine {
             index_buffer    = 1 << 2,
             viewport        = 1 << 3,
             pipeline        = 1 << 4,
+            scissors        = 1 << 5,
         };
 
         struct render_context_state {
@@ -26,6 +27,7 @@ namespace rengine {
             core::hash_t prev_vbuffer_offsets_hash{ 0 };
             core::hash_t prev_ibuffer_hash{ 0 };
             core::hash_t prev_viewport_hash{ 0 };
+            core::hash_t prev_scissor_hash{ 0 };
             pipeline_state_t prev_pipeline_id { no_pipeline_state };
             srb_t prev_srb{ no_srb };
         };
@@ -45,6 +47,7 @@ namespace rengine {
         void renderer__set_vbuffers();
         void renderer__set_ibuffer();
         void renderer__set_viewport();
+        void renderer__set_scissor_rects();
         void renderer__set_pipeline();
         void renderer__set_srb();
         void renderer__submit_render_state();

--- a/source/rengine/strings.h
+++ b/source/rengine/strings.h
@@ -187,8 +187,9 @@ namespace rengine {
             constexpr static c_str g_buffer_mgr_update_data_size_is_greater_than_buffer = "Upload data size ({0}) is greater than Buffer '{2}' size ({3}). "
                 "Engine will copy partial data to GPU, next time try to increate buffer size! "
                 "Upload Size = {0}, Buffer Id = {1} Buffer Name = {2}, Buffer Size = {3}, Buffer Type = {4}";
-            constexpr static c_str g_buffer_mgr_free_invalid_buffer = "Can´t free an invalid buffer. Buffer Id = {0}";
-			constexpr static c_str g_buffer_mgr_cant_unmap = "Can´t unmap buffer. Buffer is not mapped. Buffer Id = {0}, Buffer Type = {1}";
+            constexpr static c_str g_render_isnt_allowed_to_set_scissor_grt_than_max = "Number of scissors ({0}) is greater than max allowed ({1})";
+            constexpr static c_str g_buffer_mgr_free_invalid_buffer = "CanÂ´t free an invalid buffer. Buffer Id = {0}";
+			constexpr static c_str g_buffer_mgr_cant_unmap = "CanÂ´t unmap buffer. Buffer is not mapped. Buffer Id = {0}, Buffer Type = {1}";
             constexpr static c_str g_buffer_mgr_realloc_internal_dyn_buffer = "You are trying to realloc an internal dynamic buffer. Please, use '{0}({1} /*buffer id*/, {2}/*new buffer size*/)' method instead. "
                 "Engine will fix this problem for you by updating internal state. "
                 "To avoid any kind of side-effects, always call the required method!";
@@ -255,7 +256,7 @@ namespace rengine {
 
             constexpr static c_str g_renderer_rt_idx_grt_than_max = "Render Target Index is greater than the max supported render targets {0}";
             constexpr static c_str g_renderer_rt_idx_grt_than_set = "Render Target Index ({0}) is greater than set render targets ({1})";
-            constexpr static c_str g_renderer_clear_depth_without_set = "Can´t clear Depth Stencil. You must assign depth stencil first";
+            constexpr static c_str g_renderer_clear_depth_without_set = "CanÂ´t clear Depth Stencil. You must assign depth stencil first";
         
             constexpr static c_str g_drawing_failed_to_alloc_vbuffer = "Failed to allocate vertex buffer with size {0}";
             constexpr static c_str g_drawing_failed_to_alloc_ibuffer = "Failed to allocate index buffer with size {0}";


### PR DESCRIPTION
## Summary
- add `GRAPHICS_MAX_SCISSORS` constant and strings for errors
- track scissor rectangles in render commands
- compute scissor hashes and update renderer state
- expose renderer and command functions for scissor rects
- implement scissor support in ImGui rendering

## Testing
- `cmake ..` *(fails: Unable to find OpenGL)*
- `cmake --build . -j $(nproc)` *(fails: No rule to make target 'Makefile')*

------
https://chatgpt.com/codex/tasks/task_e_684b209d78e483279577e77ca2bbcbf8