### PR TITLE
Add image resource implementation

### DIFF
--- a/source/rengine/exceptions.h
+++ b/source/rengine/exceptions.h
@@ -28,7 +28,10 @@ namespace rengine {
 		ENGINE_DEFINE_EXCEPTION(logger_exception);
 	}
 
-	namespace graphics {
-		ENGINE_DEFINE_EXCEPTION(graphics_exception);
-	}
+        namespace graphics {
+                ENGINE_DEFINE_EXCEPTION(graphics_exception);
+        }
+        namespace resources {
+                ENGINE_DEFINE_EXCEPTION(resource_exception);
+        }
 }

--- a/source/rengine/rengine.cpp
+++ b/source/rengine/rengine.cpp
@@ -6,6 +6,7 @@
 #include "./core/profiler_private.h"
 #include "./graphics/graphics_private.h"
 #include "./io/logger_private.h"
+#include "./resources/resources_private.h"
 
 namespace rengine {
 	void init() {
@@ -18,12 +19,13 @@ namespace rengine {
 		if (desc.window_id != core::no_window)
 			use_window(desc.window_id);
 
-		action_t actions[] = {
-			core::string_pool__init,
-			io::logger__init,
-			core::window__init,
-			core::profiler__init,
-		};
+                action_t actions[] = {
+                        core::string_pool__init,
+                        io::logger__init,
+                        core::window__init,
+                        core::profiler__init,
+                        resources::resources__init,
+                };
 
 		for(u32 i = 0; i < _countof(actions); ++i)
 			actions[i]();
@@ -38,13 +40,14 @@ namespace rengine {
 	void destroy() {
 		EVENT_EMIT(engine, destroy)();
 
-		action_t actions[] = {
-			graphics::deinit,
-			core::window__deinit,
-			io::logger__deinit,
-			core::profiler__deinit,
-			core::string_pool__deinit,
-		};
+                action_t actions[] = {
+                        graphics::deinit,
+                        core::window__deinit,
+                        io::logger__deinit,
+                        core::profiler__deinit,
+                        resources::resources__deinit,
+                        core::string_pool__deinit,
+                };
 
 		for (u32 i = 0; i < _countof(actions); ++i)
 			actions[i]();

--- a/source/rengine/resources/image.cpp
+++ b/source/rengine/resources/image.cpp
@@ -1,11 +1,186 @@
 #include "image.h"
 #include "./image_private.h"
+#include "../graphics/texture_manager.h"
+#include "../exceptions.h"
+#include "../strings.h"
+#include "../io/logger.h"
+#include <cstring>
 
 namespace rengine {
-	namespace resources {
-		image_t* image_create(const image_create_desc& desc)
-		{
-			return image__alloc(desc);
-		}
-	}
+        namespace resources {
+                image_t* image_create(const image_create_desc& desc)
+                {
+                        return image__alloc(desc);
+                }
+
+                void image_destroy(image_t* image)
+                {
+                        image__destroy(image);
+                }
+
+                void image_get_pixelbuffer(const image_t* image, ptr* pixelbuffer_out, u32* pixelbuffer_size)
+                {
+                        if(!image)
+                                return;
+
+                        if(pixelbuffer_out)
+                                *pixelbuffer_out = (ptr)((byte*)image + sizeof(image_t));
+
+                        if(pixelbuffer_size)
+                                *pixelbuffer_size = image->size.x * image->size.y * image->components;
+                }
+
+                void image_set_pixelbuffer(image_t* image, const ptr data)
+                {
+                        if(!image || !data)
+                                return;
+
+                        ptr dst; u32 size;
+                        image_get_pixelbuffer(image, &dst, &size);
+                        memcpy(dst, data, size);
+                }
+
+                void image_get_size(const image_t* image, math::uvec2& size)
+                {
+                        if(!image)
+                                return;
+                        size = image->size;
+                }
+
+                void image_resize(image_t* image, const math::uvec2& size)
+                {
+                        (void)image; (void)size;
+                        throw not_implemented_exception();
+                }
+
+                void image_set_pixel(image_t* image, const image_pixel_set_desc& desc)
+                {
+                        if(!image)
+                                return;
+
+                        math::uvec2 pos = desc.pos;
+                        image__validate_pos(image, pos);
+
+                        ptr pixelbuffer; u32 size;
+                        image_get_pixelbuffer(image, &pixelbuffer, &size);
+                        byte* buf = (byte*)pixelbuffer;
+                        u32 index = pos.y * image->size.x + pos.x;
+                        byte* dst = buf + index * image->components;
+
+                        switch(image->components)
+                        {
+                        case 1:
+                                dst[0] = desc.color.r;
+                                break;
+                        case 2:
+                                dst[0] = desc.color.r;
+                                dst[1] = desc.color.g;
+                                break;
+                        case 3:
+                                dst[0] = desc.color.r;
+                                dst[1] = desc.color.g;
+                                dst[2] = desc.color.b;
+                                break;
+                        default:
+                                dst[0] = desc.color.r;
+                                dst[1] = desc.color.g;
+                                dst[2] = desc.color.b;
+                                dst[3] = desc.color.a;
+                                break;
+                        }
+                }
+
+                void image_get_pixel(const image_t* image, const math::uvec2& pos, math::color& color)
+                {
+                        if(!image)
+                                return;
+
+                        math::uvec2 p = pos;
+                        image__validate_pos(image, p);
+
+                        ptr pixelbuffer; u32 size;
+                        image_get_pixelbuffer(image, &pixelbuffer, &size);
+                        byte* buf = (byte*)pixelbuffer;
+                        u32 index = p.y * image->size.x + p.x;
+                        byte* src = buf + index * image->components;
+
+                        switch(image->components)
+                        {
+                        case 1:
+                                color.r = src[0] / 255.f;
+                                color.g = color.b = 0.f;
+                                color.a = 1.f;
+                                break;
+                        case 2:
+                                color.r = src[0] / 255.f;
+                                color.g = src[1] / 255.f;
+                                color.b = 0.f;
+                                color.a = 1.f;
+                                break;
+                        case 3:
+                                color.r = src[0] / 255.f;
+                                color.g = src[1] / 255.f;
+                                color.b = src[2] / 255.f;
+                                color.a = 1.f;
+                                break;
+                        default:
+                                color.r = src[0] / 255.f;
+                                color.g = src[1] / 255.f;
+                                color.b = src[2] / 255.f;
+                                color.a = src[3] / 255.f;
+                                break;
+                        }
+                }
+
+                static bool image__validate_format(u8 comps, graphics::texture_format fmt)
+                {
+                        switch(fmt)
+                        {
+                        case graphics::texture_format::bc1_dxt1:
+                        case graphics::texture_format::bc3_dxt5:
+                        case graphics::texture_format::bc4:
+                        case graphics::texture_format::bc5:
+                        case graphics::texture_format::bc6h:
+                        case graphics::texture_format::bc7:
+                                throw resources::resource_exception(strings::exceptions::g_image_invalid_compressed_format);
+                        case graphics::texture_format::r8:
+                        case graphics::texture_format::d16:
+                        case graphics::texture_format::d24s8:
+                        case graphics::texture_format::d32s8:
+                        case graphics::texture_format::d32f:
+                                return comps == 1;
+                        case graphics::texture_format::rg8:
+                                return comps == 2;
+                        default:
+                                return comps >= 3 && comps <= 4;
+                        }
+                }
+
+                graphics::texture_2d_t image_create_texture(const image_texture_create_desc& desc)
+                {
+                        if(!desc.source)
+                                throw null_exception(strings::exceptions::g_image_create_texture_source_null);
+
+                        auto* img = desc.source;
+                        if(!image__validate_format(img->components, desc.format))
+                                throw resources::resource_exception(strings::exceptions::g_image_invalid_format);
+
+                        ptr pixelbuffer; u32 size;
+                        image_get_pixelbuffer(img, &pixelbuffer, &size);
+
+                        graphics::texture_create_desc<graphics::texture_2d_size> tex_desc;
+                        tex_desc.name = desc.name;
+                        tex_desc.size = { img->size.x, img->size.y };
+                        tex_desc.format = desc.format;
+                        tex_desc.usage = desc.usage;
+                        tex_desc.generate_mips = desc.generate_mips;
+                        tex_desc.readable = desc.readable;
+
+                        graphics::texture_resource_data data{};
+                        data.data = pixelbuffer;
+                        data.stride = img->components;
+
+                        return graphics::texture_mgr_create_tex2d(tex_desc, data);
+                }
+        }
 }

--- a/source/rengine/resources/image.h
+++ b/source/rengine/resources/image.h
@@ -48,7 +48,7 @@ namespace rengine {
 		R_EXPORT void image_resize(image_t* image, const math::uvec2& size);
 
 		R_EXPORT void image_set_pixel(image_t* image, const image_pixel_set_desc& desc);
-		R_EXPORT void image_get_pixel(const image_t* image, const math::uvec2& pos, image_pixel_color& color);
+                R_EXPORT void image_get_pixel(const image_t* image, const math::uvec2& pos, math::color& color);
 
 		R_EXPORT graphics::texture_2d_t image_create_texture(const image_texture_create_desc& desc);
 	}

--- a/source/rengine/resources/image_private.cpp
+++ b/source/rengine/resources/image_private.cpp
@@ -1,34 +1,57 @@
 #include "image_private.h"
 #include "../core/allocator.h"
+#include "../io/logger.h"
+#include "../strings.h"
+#include <fmt/format.h>
 
 namespace rengine {
-	namespace resources {
-		void image__init()
-		{
-			g_image_state = {};
-		}
+        namespace resources {
+                void image__init()
+                {
+                        g_image_state = {};
+                        g_image_state.log = io::logger_use(strings::logs::g_image_tag);
+                }
 		
-		void image__deinit()
-		{
-			image__free_images();
-			g_image_state = {};
-		}
+                void image__deinit()
+                {
+                        image__free_images();
+                        g_image_state = {};
+                }
+
+                void image__validate_pos(const image_t* img, math::uvec2& pos)
+                {
+                        if (!img)
+                                return;
+
+                        if (pos.x >= img->size.x || pos.y >= img->size.y) {
+                                const auto log = g_image_state.log;
+                                if (log) {
+                                        log->warn(
+                                                fmt::format(strings::logs::g_image_pos_exceeds_bounds,
+                                                        pos.x, pos.y, img->size.x, img->size.y)
+                                                        .c_str());
+                                }
+                                pos.x = math::min<u32>(pos.x, img->size.x - 1);
+                                pos.y = math::min<u32>(pos.y, img->size.y - 1);
+                        }
+                }
 
 		image_t* image__alloc(const image_create_desc& desc)
 		{
 			auto& state = g_image_state;
 			auto pixelbuffer_size = desc.size.x * desc.size.y * desc.components;
 
-			image_t* img = (image_t*)core::alloc(sizeof(image_t) + pixelbuffer_size);
-			img->prev = state.root;
-			img->next = null;
-			img->size = desc.size;
-			img->components = desc.components;
-			if(state.root)
-				state.root->next = img;
-			state.root = img;
-			return img;
-		}
+                        image_t* img = (image_t*)core::alloc(sizeof(image_t) + pixelbuffer_size);
+                        img->prev = state.root;
+                        img->next = null;
+                        img->size = desc.size;
+                        img->components = desc.components;
+                        if(state.root)
+                                state.root->next = img;
+                        state.root = img;
+                        state.num_images++;
+                        return img;
+                }
 
 		void image__free_images()
 		{

--- a/source/rengine/resources/image_private.h
+++ b/source/rengine/resources/image_private.h
@@ -1,5 +1,7 @@
 #pragma once
 #include "./image.h"
+#include "../io/logger.h"
+#include "../strings.h"
 
 namespace rengine {
 	namespace resources {
@@ -10,10 +12,13 @@ namespace rengine {
 			u8 components{ 4 };
 		};
 
-		struct image_state {
-			u32 num_images{ 0 };
-			image_t* root{ null };
-		};
+               struct image_state {
+                       u32 num_images{ 0 };
+                       image_t* root{ null };
+                        io::ILog* log{ null };
+               };
+
+               void image__validate_pos(const image_t* img, math::uvec2& pos);
 
 		extern image_state g_image_state;
 

--- a/source/rengine/resources/resources_private.cpp
+++ b/source/rengine/resources/resources_private.cpp
@@ -1,0 +1,12 @@
+#include "resources_private.h"
+
+namespace rengine {
+    namespace resources {
+        void resources__init() {
+            image__init();
+        }
+        void resources__deinit() {
+            image__deinit();
+        }
+    }
+}

--- a/source/rengine/resources/resources_private.h
+++ b/source/rengine/resources/resources_private.h
@@ -1,0 +1,9 @@
+#pragma once
+#include "image_private.h"
+
+namespace rengine {
+    namespace resources {
+        void resources__init();
+        void resources__deinit();
+    }
+}

--- a/source/rengine/strings.h
+++ b/source/rengine/strings.h
@@ -171,6 +171,10 @@ namespace rengine {
             constexpr static c_str g_drawing_cmd_tag = "drawing";
             constexpr static c_str g_srb_mgr_tag = "srb";
             constexpr static c_str g_tex_mgr_tag = "texture_mgr";
+            constexpr static c_str g_image_tag = "image";
+
+            constexpr static c_str g_image_pos_exceeds_bounds =
+                "Position exceeds Image Bounds. pos.x = {0}, pos.y = {1}, width = {2}, height = {3}";
 
             constexpr static c_str g_logger_fmt = "[{0}/{1}/{2} {3}:{4}:{5}][{6}][{7}]: {8}";
 
@@ -267,6 +271,9 @@ namespace rengine {
             constexpr static c_str g_render_cmd_cant_build_render_cmd = "Failed to create render command. Reached limit of {0} render commands";
         
             constexpr static c_str g_srb_invalid_pipeline = "Failed to create Shader Resource Binding. Pipeline State Id is invalid. Pipeline State = {0}";
+            constexpr static c_str g_image_create_texture_source_null = "image_create_texture: source is null";
+            constexpr static c_str g_image_invalid_format = "image_create_texture: invalid format for image components";
+            constexpr static c_str g_image_invalid_compressed_format = "Image doesn't supports compressed formats";
         }
     }
 }


### PR DESCRIPTION
## Summary
- implement image pixel manipulation functions
- validate format when creating texture from an image
- integrate image init/deinit into engine lifecycle
- refactor pixel bounds check into helper

## Testing
- `cmake -B build` *(fails: `Configuring incomplete, errors occurred`)*
- `cmake --build build` *(fails: `No rule to make target 'Makefile'`)*

------
https://chatgpt.com/codex/tasks/task_e_6855f285650c832786eefa1338891364