### PR TITLE
Add shaders and compile via Slang

### DIFF
--- a/assets/shaders/drawing_ps.slang
+++ b/assets/shaders/drawing_ps.slang
@@ -1,0 +1,8 @@
+struct ps_input {
+    float4 position : SV_Position;
+    float4 color    : COLOR0;
+    float2 uv       : TEXCOORD0;
+};
+float4 main(in ps_input input) : SV_Target {
+    return input.color;
+}

--- a/assets/shaders/drawing_vs.slang
+++ b/assets/shaders/drawing_vs.slang
@@ -1,0 +1,69 @@
+cbuffer frame_constants {
+    float4x4 g_screen_projection;
+    float2 g_window_size;
+    float g_delta_time;
+    float g_elapsed_time;
+    uint g_frame;
+};
+
+struct vs_input {
+#if defined(POSITION_ATTR)
+    float3 position : POSITION_ATTR;
+#endif
+#if defined(COLOR_ATTR)
+    uint color      : COLOR_ATTR;
+#endif
+#if defined(COLORF_ATTR)
+    float4 colorf   : COLORF_ATTR;
+#endif
+#if defined(UV_ATTR)
+    float2 uv           : UV_ATTR;
+#endif
+};
+
+struct vs_output {
+    float4 position : SV_Position;
+    float4 color    : COLOR0;
+    float2 uv       : TEXCOORD0;
+};
+
+vs_output main(in vs_input input) {
+    vs_output output = (vs_output)0;
+
+#if defined(POSITION_ATTR)
+    float4 vertex_position = float4(input.position, 1.0f);
+#else
+    float4 vertex_position = float4(0.0f, 0.0f, 0.0f, 1.0f);
+#endif
+
+#if defined(COLORF_ATTR)
+    float4 color_float = input.colorf;
+#else
+    float4 color_float = float4(0, 0, 0, 1);
+#endif
+
+#if defined(COLOR_ATTR)
+    uint color_int = input.color;
+#else
+    uint color_int = 0;
+#endif
+    float4 color = float4(
+        (float)((color_int >> 0) & 0xFF),
+        (float)((color_int >> 8) & 0xFF),
+        (float)((color_int >> 16) & 0xFF),
+        (float)((color_int >> 24) & 0xFF)
+    );
+    color /= float4(255.0f, 255.0f, 255.0f, 255.0f);
+
+#if defined(UV_ATTR)
+    float2 uv = input.uv;
+#else
+    float2 uv = float2(0.0f, 0.0f);
+#endif
+
+    output.position = mul(g_screen_projection, vertex_position);
+    output.color = color + color_float;
+    output.color.a *= 0.5;
+    output.uv = uv;
+    return output;
+}

--- a/assets/shaders/imgui_ps.slang
+++ b/assets/shaders/imgui_ps.slang
@@ -1,0 +1,11 @@
+Texture2D    g_texture;
+SamplerState g_texture_sampler;
+
+struct ps_input {
+    float4 position : SV_Position;
+    float4 color    : COLOR0;
+    float2 uv           : TEXCOORD0;
+};
+float4 main(in ps_input input) : SV_Target {
+    return input.color * g_texture.Sample(g_texture_sampler, input.uv);
+}

--- a/source/tools/material_compiler/main.cpp
+++ b/source/tools/material_compiler/main.cpp
@@ -1,11 +1,118 @@
 #include <iostream>
+#include <fstream>
+#include <vector>
+#include <string>
+#include <filesystem>
+
 #include <slang.h>
+#include <slang-com-helper.h>
+
 #include <rengine/rengine.h>
+
+using namespace slang;
+
+namespace
+{
+SlangStage guessStage(const std::string& path)
+{
+    auto filename = std::filesystem::path(path).filename().string();
+    for (auto& c : filename) c = (char)std::tolower(c);
+
+    if (filename.find("vs") != std::string::npos || filename.find("vert") != std::string::npos)
+        return SLANG_STAGE_VERTEX;
+    if (filename.find("ps") != std::string::npos || filename.find("frag") != std::string::npos)
+        return SLANG_STAGE_FRAGMENT;
+    if (filename.find("cs") != std::string::npos || filename.find("comp") != std::string::npos)
+        return SLANG_STAGE_COMPUTE;
+    return SLANG_STAGE_NONE;
+}
+
+}
 
 int main(int argc, char** argv)
 {
+    if (argc < 2)
+    {
+        std::cerr << "Usage: material_compiler <shader file>" << std::endl;
+        return 1;
+    }
+
+    const std::string shaderPath = argv[1];
+
+    std::ifstream file(shaderPath, std::ios::binary);
+    if (!file)
+    {
+        std::cerr << "Failed to open file: " << shaderPath << std::endl;
+        return 1;
+    }
+
+    std::string source((std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>());
+
     rengine::init();
-    std::cout << "Slang version: " << spGetBuildTagString() << std::endl;
+
+    SlangSession* session = spCreateSession(nullptr);
+    SlangCompileRequest* request = spCreateCompileRequest(session);
+
+    int translationUnit = spAddTranslationUnit(request, SLANG_SOURCE_LANGUAGE_SLANG, "shader");
+    spAddTranslationUnitSourceString(request, translationUnit, shaderPath.c_str(), source.c_str());
+
+    SlangStage stage = guessStage(shaderPath);
+    if (stage != SLANG_STAGE_NONE)
+        spAddEntryPoint(request, translationUnit, "main", stage);
+
+    if (spCompile(request) != SLANG_OK)
+    {
+        const char* diagnostic = spGetDiagnosticOutput(request);
+        if (diagnostic)
+            std::cerr << diagnostic << std::endl;
+        spDestroyCompileRequest(request);
+        spDestroySession(session);
+        rengine::destroy();
+        return 1;
+    }
+
+    std::cout << "Slang compilation succeeded" << std::endl;
+
+    ProgramLayout* program = ProgramLayout::get(request);
+    SlangUInt paramCount = program->getParameterCount();
+
+    for (SlangUInt i = 0; i < paramCount; ++i)
+    {
+        auto* param = program->getParameterByIndex(i);
+        auto* var = param->getVariable();
+        auto* typeLayout = param->getTypeLayout();
+        auto* type = typeLayout->getType();
+
+        auto kind = type->getKind();
+        auto category = param->getCategory();
+
+        if (kind == TypeReflection::Kind::ConstantBuffer)
+        {
+            std::cout << "ConstantBuffer: " << var->getName() << std::endl;
+        }
+        else if (category == ParameterCategory::VaryingInput)
+        {
+            const char* semantic = param->getSemanticName();
+            std::cout << "VertexInput: " << var->getName();
+            if (semantic)
+                std::cout << " (" << semantic << param->getSemanticIndex() << ")";
+            std::cout << std::endl;
+        }
+        else if (typeLayout->getBindingRangeCount() > 0)
+        {
+            for (SlangInt r = 0; r < typeLayout->getBindingRangeCount(); ++r)
+            {
+                auto bindingType = typeLayout->getBindingRangeType(r);
+                if (bindingType == BindingType::Texture)
+                {
+                    std::cout << "Texture: " << var->getName() << std::endl;
+                }
+            }
+        }
+    }
+
+    spDestroyCompileRequest(request);
+    spDestroySession(session);
     rengine::destroy();
     return 0;
 }


### PR DESCRIPTION
## Summary
- add Slang versions of built-in shaders under `assets/shaders`
- extend `material_compiler` to read files, compile them with Slang, and dump reflection info

## Testing
- `cmake -B build` *(fails: Unable to finish build)*

------
https://chatgpt.com/codex/tasks/task_e_687a9842bb9c8327ace058bf47bd3c7e